### PR TITLE
Refactor moderation flags for granular control

### DIFF
--- a/src/checkHandles.ts
+++ b/src/checkHandles.ts
@@ -3,13 +3,18 @@ import logger from "./logger.js";
 import { Handle } from "./types.js";
 import {
   createAccountReport,
+  createAccountComment,
   createAccountLabel,
   checkAccountLabels,
 } from "./moderation.js";
 import { limit } from "./limits.js";
 
-export const checkHandle = async (handle: Handle[]) => {
-  const ActLabelChk = await limit(() => checkAccountLabels(handle[0].did));
+export const checkHandle = async (
+  did: string,
+  handle: string,
+  time: number,
+) => {
+  const ActLabelChk = await limit(() => checkAccountLabels(did));
   // Get a list of labels
   const labels: string[] = Array.from(
     HANDLE_CHECKS,
@@ -23,44 +28,39 @@ export const checkHandle = async (handle: Handle[]) => {
     );
 
     if (checkList?.ignoredDIDs) {
-      if (checkList.ignoredDIDs.includes(handle[0].did)) {
-        return logger.info(`Whitelisted DID: ${handle[0].did}`);
+      if (checkList.ignoredDIDs.includes(did)) {
+        logger.info(`Whitelisted DID: ${did}`);
+        return;
       }
-    } else {
-      if (checkList!.check.test(handle[0].handle)) {
-        if (checkList?.whitelist) {
-          // False-positive checks
-          if (checkList?.whitelist.test(handle[0].handle)) {
-            logger.info(`Whitelisted phrase found for: ${handle[0].handle}`);
-            return;
-          }
-        } else {
-          logger.info(`${checkList!.label} in handle: ${handle[0].handle}`);
-        }
+    }
 
-        if (checkList?.reportOnly === true) {
-          logger.info(`Report only: ${handle[0].handle}`);
-          createAccountReport(
-            handle[0].did,
-            `${handle[0].time}: ${checkList!.comment} - ${handle[0].handle}`,
-          );
+    if (checkList!.check.test(handle)) {
+      // False-positive checks
+      if (checkList?.whitelist) {
+        if (checkList?.whitelist.test(handle)) {
+          logger.info(`Whitelisted phrase found for: ${handle}`);
           return;
-        } else {
-          if (ActLabelChk) {
-            if (ActLabelChk.includes(checkList!.label)) {
-              logger.info(
-                `Label ${checkList!.label} already exists for ${did}`,
-              );
-              return;
-            } else {
-              createAccountLabel(
-                handle[0].did,
-                `${checkList!.label}`,
-                `${handle[0].time}: ${checkList!.comment} - ${handle[0].handle}`,
-              );
-            }
-          }
         }
+      }
+
+      if (checkList?.toLabel === true) {
+        {
+          createAccountLabel(
+            did,
+            `${checkList!.label}`,
+            `${time}: ${checkList!.comment} - ${handle}`,
+          );
+        }
+      }
+
+      if (checkList?.reportAcct === true) {
+        logger.info(`Report only: ${handle}`);
+        createAccountReport(did, `${time}: ${checkList!.comment} - ${handle}`);
+      }
+
+      if (checkList?.commentAcct === true) {
+        logger.info(`Comment only: ${handle}`);
+        createAccountComment(did, `${time}: ${checkList!.comment} - ${handle}`);
       }
     }
   });

--- a/src/checkPosts.ts
+++ b/src/checkPosts.ts
@@ -14,9 +14,6 @@ export const checkPosts = async (post: Post[]) => {
     (postCheck) => postCheck.label,
   );
 
-  // Destructure Post object
-  const { did, time, atURI, text, cid } = post[0];
-
   // iterate through the labels
   labels.forEach((label) => {
     const checkPost = POST_CHECKS.find(
@@ -24,56 +21,46 @@ export const checkPosts = async (post: Post[]) => {
     );
 
     if (checkPost?.ignoredDIDs) {
-      if (checkPost.ignoredDIDs.includes(did)) {
-        return logger.info(`Whitelisted DID: ${did}`);
+      if (checkPost?.ignoredDIDs.includes(post[0].did)) {
+        logger.info(`Whitelisted DID: ${post[0].did}`);
+        return;
       }
-    } else {
-      if (checkPost!.check.test(text)) {
-        if (checkPost?.whitelist) {
-          if (checkPost?.whitelist.test(text)) {
-            logger.info(`Whitelisted phrase found"`);
-            return;
-          }
-        } else {
-          logger.info(`${checkPost!.label} in post at ${atURI}`);
+    }
 
-          if (checkPost!.reportOnly === true) {
-            logger.info(`Report only: ${did}`);
-            createAccountReport(
-              did,
-              `${time}: ${checkPost?.comment} at ${atURI} with text "${text}"`,
-            );
-            return;
-          } else {
-            logger.info(`Labeling post: ${atURI}`);
-
-            createPostLabel(
-              post[0].atURI,
-              post[0].cid,
-              `${checkPost!.label}`,
-              `${post[0].time}: ${checkPost!.comment} at ${post[0].atURI} with text "${post[0].text}"`,
-            );
-
-            if (checkPost!.commentOnly === true) {
-              logger.info(`Comment only: ${post[0].did}`);
-              createAccountComment(
-                post[0].did,
-                `${post[0].time}: ${checkPost?.comment} at ${post[0].atURI} with text "${post[0].text}"`,
-              );
-              return;
-            } else if (checkPost?.label === "fundraising-link" || checkPost?.label === "twitter-x") {
-              return; // skip fundraising links—hardcoded because of the insane volume by spammers.
-            } else if (checkPost!.commentOnly === false) {
-              logger.info(
-                `Creating report for post ${post[0].atURI} on ${post[0].did}`,
-              );
-              createAccountReport(
-                post[0].did,
-                ` ${post[0].time}: ${checkPost!.comment} at ${post[0].atURI} with text "${post[0].text}"`,
-              );
-            }
-          }
+    if (checkPost!.check.test(post[0].text)) {
+      // Check if post is whitelisted
+      if (checkPost?.whitelist) {
+        if (checkPost?.whitelist.test(post[0].text)) {
+          logger.info(`Whitelisted phrase found"`);
+          return;
         }
+      }
+
+      if (checkPost!.toLabel === true) {
+        logger.info(`Labeling post: ${post[0].atURI} for ${checkPost!.label}`);
+        createPostLabel(
+          post[0].atURI,
+          post[0].cid,
+          `${checkPost!.label}`,
+          `${post[0].time}: ${checkPost!.comment} at ${post[0].atURI} with text "${post[0].text}"`,
+        );
+      }
+
+      if (checkPost!.reportAcct === true) {
+        logger.info(`${checkPost!.label} in post at ${post[0].atURI}`);
+        logger.info(`Report only: ${post[0].did}`);
+        createAccountReport(
+          post[0].did,
+          `${post[0].time}: ${checkPost?.comment} at ${post[0].atURI} with text "${post[0].text}"`,
+        );
+      }
+
+      if (checkPost!.commentAcct === true) {
+        logger.info(`Comment on account: ${post[0].did}`);
+        createAccountComment(
+          post[0].did,
+          `${post[0].time}: ${checkPost?.comment} at ${post[0].atURI} with text "${post[0].text}"`,
+        );
       }
     }
   });

--- a/src/checkProfiles.ts
+++ b/src/checkProfiles.ts
@@ -5,6 +5,7 @@ import {
   createAccountReport,
   createAccountLabel,
   checkAccountLabels,
+  createAccountComment,
 } from "./moderation.js";
 import { limit } from "./limits.js";
 
@@ -14,8 +15,6 @@ export const checkDescription = async (
   displayName: string,
   description: string,
 ) => {
-  const ActLabelChk = await limit(() => checkAccountLabels(did));
-  // Get a list of labels
   const labels: string[] = Array.from(
     PROFILE_CHECKS,
     (profileCheck) => profileCheck.label,
@@ -30,43 +29,44 @@ export const checkDescription = async (
     // Check if DID is whitelisted
     if (checkProfiles?.ignoredDIDs) {
       if (checkProfiles.ignoredDIDs.includes(did)) {
-        return logger.info(`Whitelisted DID: ${did}`);
+        logger.info(`Whitelisted DID: ${did}`);
+        return;
       }
     }
 
     if (description) {
       if (checkProfiles?.description === true) {
         if (checkProfiles!.check.test(description)) {
+          // Check if description is whitelisted
           if (checkProfiles!.whitelist) {
             if (checkProfiles!.whitelist.test(description)) {
               logger.info(`Whitelisted phrase found.`);
               return;
             }
-          } else {
-            logger.info(`${checkProfiles!.label} in description for ${did}`);
           }
 
-          if (checkProfiles!.reportOnly === true) {
+          if (checkProfiles!.toLabel === true) {
+            logger.info(`Creating label for ${did}`);
+            createAccountLabel(
+              did,
+              `${checkProfiles!.label}`,
+              `${time}: ${checkProfiles!.comment} - ${displayName} - ${description}`,
+            );
+          }
+
+          if (checkProfiles!.reportAcct === true) {
             createAccountReport(
               did,
               `${time}: ${checkProfiles!.comment} - ${displayName} - ${description}`,
             );
-            return;
-          } else {
-            if (ActLabelChk) {
-              if (ActLabelChk.includes(checkProfiles!.label)) {
-                logger.info(
-                  `Label ${checkProfiles!.label} already exists for ${did}`,
-                );
-                return;
-              }
-            } else {
-              createAccountLabel(
-                did,
-                `${checkProfiles!.label}`,
-                `${time}: ${checkProfiles!.comment} - ${displayName} - ${description}`,
-              );
-            }
+          }
+
+          if (checkProfiles!.commentAcct === true) {
+            logger.info(`Commenting on account for ${did}`);
+            createAccountComment(
+              did,
+              `${time}: ${checkProfiles!.comment} - ${displayName} - ${description}`,
+            );
           }
         }
       }
@@ -80,7 +80,6 @@ export const checkDisplayName = async (
   displayName: string,
   description: string,
 ) => {
-  const ActLabelChk = await limit(() => checkAccountLabels(did));
   // Get a list of labels
   const labels: string[] = Array.from(
     PROFILE_CHECKS,
@@ -96,43 +95,42 @@ export const checkDisplayName = async (
     // Check if DID is whitelisted
     if (checkProfiles?.ignoredDIDs) {
       if (checkProfiles.ignoredDIDs.includes(did)) {
-        return logger.info(`Whitelisted DID: ${did}`);
+        logger.info(`Whitelisted DID: ${did}`);
+        return;
       }
     }
 
     if (displayName) {
       if (checkProfiles?.displayName === true) {
         if (checkProfiles!.check.test(displayName)) {
+          // Check if displayName is whitelisted
           if (checkProfiles!.whitelist) {
             if (checkProfiles!.whitelist.test(displayName)) {
               logger.info(`Whitelisted phrase found.`);
               return;
             }
-          } else {
-            logger.info(`${checkProfiles!.label} in displayName for ${did}`);
           }
 
-          if (checkProfiles!.reportOnly === true) {
+          if (checkProfiles!.toLabel === true) {
+            createAccountLabel(
+              did,
+              `${checkProfiles!.label}`,
+              `${time}: ${checkProfiles!.comment} - ${displayName} - ${description}`,
+            );
+          }
+
+          if (checkProfiles!.reportAcct === true) {
             createAccountReport(
               did,
               `${time}: ${checkProfiles!.comment} - ${displayName} - ${description}`,
             );
-            return;
-          } else {
-            if (ActLabelChk) {
-              if (ActLabelChk.includes(checkProfiles!.label)) {
-                logger.info(
-                  `Label ${checkProfiles!.label} already exists for ${did}`,
-                );
-                return;
-              }
-            } else {
-              createAccountLabel(
-                did,
-                `${checkProfiles!.label}`,
-                `${time}: ${checkProfiles!.comment} - ${displayName} - ${description}`,
-              );
-            }
+          }
+
+          if (checkProfiles!.commentAcct === true) {
+            createAccountComment(
+              did,
+              `${time}: ${checkProfiles!.comment} - ${displayName} - ${description}`,
+            );
           }
         }
       }

--- a/src/checkStarterPack.ts
+++ b/src/checkStarterPack.ts
@@ -1,6 +1,10 @@
-import { PROFILE_CHECKS } from "./constants.js";
+import { PROFILE_CHECKS, STARTERPACK_CHECKS } from "./constants.js";
 import logger from "./logger.js";
-import { createAccountLabel } from "./moderation.js";
+import {
+  createAccountLabel,
+  createAccountReport,
+  createPostLabel,
+} from "./moderation.js";
 
 export const checkStarterPack = async (
   did: string,
@@ -36,6 +40,69 @@ export const checkStarterPack = async (
             `${time}: ${checkProfiles!.comment} - Account joined via starter pack at: ${atURI}`,
           );
         }
+      }
+    }
+  });
+};
+
+export const checkNewStarterPack = async (
+  did: string,
+  time: number,
+  atURI: string,
+  cid: string,
+  packName: string | undefined,
+  description: string | undefined,
+) => {
+  const labels: string[] = Array.from(
+    STARTERPACK_CHECKS,
+    (SPCheck) => SPCheck.label,
+  );
+
+  labels.forEach((label) => {
+    const checkList = PROFILE_CHECKS.find((SPCheck) => SPCheck.label === label);
+
+    if (checkList?.knownVectors?.includes(did)) {
+      createPostLabel(
+        atURI,
+        cid,
+        `${checkList!.label}`,
+        `${time}: Starter pack created by known vector for ${checkList!.label} at: ${atURI}"`,
+      );
+      createAccountReport(
+        did,
+        `${time}: Starter pack created by known vector for ${checkList!.label} at: ${atURI}"`,
+      );
+    }
+
+    if (description) {
+      if (checkList!.check.test(description)) {
+        logger.info(`Labeling post: ${atURI}`);
+        createPostLabel(
+          atURI,
+          cid,
+          `${checkList!.label}`,
+          `${time}: ${checkList!.comment} at ${atURI} with text "${description}"`,
+        );
+        createAccountReport(
+          did,
+          `${time}: ${checkList!.comment} at ${atURI} with text "${description}"`,
+        );
+      }
+    }
+
+    if (packName) {
+      if (checkList!.check.test(packName)) {
+        logger.info(`Labeling post: ${atURI}`);
+        createPostLabel(
+          atURI,
+          cid,
+          `${checkList!.label}`,
+          `${time}: ${checkList!.comment} at ${atURI} with pack name "${packName}"`,
+        );
+        createAccountReport(
+          did,
+          `${time}: ${checkList!.comment} at ${atURI} with pack name "${packName}"`,
+        );
       }
     }
   });

--- a/src/constants.ts.example
+++ b/src/constants.ts.example
@@ -8,8 +8,9 @@ export const PROFILE_CHECKS: Checks[] = [
     comment: "Pro-skub language found in profile",
     description: true,
     displayName: true,
-    reportOnly: false,
-    commentOnly: false,
+    reportAcct: false,
+    commentAcct: false,
+    toLabel: true,
     check: new RegExp(
       "(only|pro)[ -]skub|we love skub|skub is (good|god|king)|\\bskub\\b",
       "i",
@@ -24,8 +25,9 @@ export const PROFILE_CHECKS: Checks[] = [
     comment: "skub-adjacent language found in profile",
     description: true,
     displayName: true,
-    reportOnly: true,
-    commentOnly: false,
+    reportAcct: false,
+    commentAcct: false,
+    toLabel: true,
     check: new RegExp(
       "skubbe",
       "i",
@@ -37,8 +39,9 @@ export const HANDLE_CHECKS: Checks[] = [
   {
     label: "skub",
     comment: "Pro-skub language found in handle",
-    reportOnly: false,
-    commentOnly: false,
+    reportAcct: false,
+    commentAcct: false,
+    toLabel: true,
     check: new RegExp(
       "(only|pro)[-]skub|we love skub|skub[-]?is[-]?(good|god|king)|skub\\.(pro|com|org)",
       "i",
@@ -50,8 +53,9 @@ export const POST_CHECKS: Checks[] = [
   {
     label: "pro-skub-link",
     comment: "Pro Skub link found in post",
-    reportOnly: true,
-    commentOnly: false,
+    reportAcct: false,
+    commentAcct: true,
+    toLabel: true,
     check: new RegExp(
       "skubbe\\.com|skub\\.(me|pro|tech)",
       "i",

--- a/src/developing_checks.md
+++ b/src/developing_checks.md
@@ -12,11 +12,12 @@ export const HANDLE_CHECKS: Checks[] = [
     comment: "Example found in handle",
     description: true, // Optional, only used in handle checks
     displayName: true, // Optional, only used in handle checks
-    reportOnly: false, // it true, the check will only report the content against the account, not label.
-    commentOnly: false, // Poorly named, if true, will generate an account level comment from flagged posts, rather than a report. Intended for use when reportOnly is false, and on posts only where the flag may generate a high volume of reports..
+    reportAcct: false, // it true, the check will only report the content against the account, not label.
+    commentOnly: false, // if true, will generate an account level comment from flagged posts, rather than a report. Intended for use when reportAcct is false, and on posts only where the flag may generate a high volume of reports.
+    toLabel: true, // Should the handle in question be labeled if check evaluates to true.
     check: new RegExp("example", "i"), // Regular expression to match against the content
     whitelist: new RegExp("example.com", "i"), // Optional, regular expression to whitelist content
-    ignoredDIDs: ["did:plc:example"] // Optional, array of DIDs to ignore if they match the check. Useful for folks who reclaim words.
+    ignoredDIDs: ["did:plc:example"] // Optional, array of DIDs to ignore if they match the check. Useful for folks who reclaim words or accounts which may be false positives.
   }
 ];
 ```

--- a/src/lists.ts
+++ b/src/lists.ts
@@ -2,7 +2,43 @@ import { List } from "./types.js";
 
 export const LISTS: List[] = [
   {
-    label: "list-name",
-    rkey: "<insert-rkey-here>",
+    label: "blue-heart-emoji",
+    rkey: "3lfbtgosyyi22",
+  },
+  {
+    label: "troll",
+    rkey: "3lbckxhgu3r2v",
+  },
+  {
+    label: "maga-trump",
+    rkey: "3l53cjwlt4o2s",
+  },
+  {
+    label: "elon-musk",
+    rkey: "3l72tte74wa2m",
+  },
+  {
+    label: "rmve-imve",
+    rkey: "3l6tfurf7li27",
+  },
+  {
+    label: "nazi-symbolism",
+    rkey: "3l6vdudxgeb2z",
+  },
+  {
+    label: "hammer-sickle",
+    rkey: "3l4ue6w2aur2v",
+  },
+  {
+    label: "inverted-red-triangle",
+    rkey: "3l4ueabtpec2a",
+  },
+  {
+    label: "automated-reply-guy",
+    rkey: "3lch7qbvzpx23",
+  },
+  {
+    label: "terf-gc",
+    rkey: "3lcqjqjdejs2x",
   },
 ];

--- a/src/moderation.ts
+++ b/src/moderation.ts
@@ -86,6 +86,46 @@ export const createAccountLabel = async (
   });
 };
 
+export const createPostReport = async (
+  uri: string,
+  cid: string,
+  comment: string,
+) => {
+  await isLoggedIn;
+  await limit(async () => {
+    try {
+      return agent.tools.ozone.moderation.emitEvent(
+        {
+          event: {
+            $type: "tools.ozone.moderation.defs#modEventReport",
+            comment: comment,
+            reportType: "com.atproto.moderation.defs#reasonOther",
+          },
+          // specify the labeled post by strongRef
+          subject: {
+            $type: "com.atproto.repo.strongRef",
+            uri: uri,
+            cid: cid,
+          },
+          // put in the rest of the metadata
+          createdBy: `${agent.did}`,
+          createdAt: new Date().toISOString(),
+        },
+        {
+          encoding: "application/json",
+          headers: {
+            "atproto-proxy": `${MOD_DID!}#atproto_labeler`,
+            "atproto-accept-labelers":
+              "did:plc:ar7c4by46qjdydhdevvrndac;redact",
+          },
+        },
+      );
+    } catch (e) {
+      console.error(e);
+    }
+  });
+};
+
 export const createAccountComment = async (did: string, comment: string) => {
   await isLoggedIn;
   await limit(async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,12 +3,14 @@ export interface Checks {
   comment: string;
   description?: boolean;
   displayName?: boolean;
-  reportOnly: boolean;
-  commentOnly: boolean;
+  reportAcct: boolean;
+  commentAcct: boolean;
+  toLabel: boolean;
   check: RegExp;
   whitelist?: RegExp;
   ignoredDIDs?: string[];
   starterPacks?: string[];
+  knownVectors?: string[];
 }
 
 export interface Post {


### PR DESCRIPTION
- Rename `reportOnly` to `reportAcct` and `commentOnly` to `commentAcct` for clarity.
- Introduce `toLabel` flag to explicitly manage item labeling. These changes allow independent control over labeling an item, reporting its author, or commenting on the author's account.

- Remove non-functional pre-check for existing labels before applying new ones in handle and profile checks.

- Add checks for starter pack content (name, description) and known vector authors.
- Implement `createPostReport` function for reporting specific posts.
- Update `checkHandle` signature for direct parameter passing.